### PR TITLE
Define Criteria For Participation

### DIFF
--- a/content/project-instructions.md
+++ b/content/project-instructions.md
@@ -1,38 +1,99 @@
-## Instructions for Projects
+## Your Project's Bug Bounty
 
-So, you want your project included in the bug bounty? **Hooray!** Here's how to get involved.
+We aim for our bug bounties to be a win for everyone involved: the project, the
+researchers, and everyone that depends on our software.
 
-In a nutshell, the requirement comes down to this: **you need to take accountability for fixing any reported issues in a reasonable time.** 18F's bug bounty team is more than happ to provide advice, guidance, and even help resolving issues. However, we won't play "cops" -- you need to be OK owning the responsibility of tracking and resolving issues.
+### Vulnerability Maturity Model
 
-### Management tasks
+Our partner, HackerOne, has [a maturity model for vulnerability coordination](https://www.hackerone.com/blog/vulnerability-coordination-maturity-model).  It
+is not strictly necessary that your project have expert-level maturity in every
+capability to participate, but in general, more maturity is better.
 
-You'll need to take care of a few management tasks while participating in the bounty:
+__Organizational__: How does your project respond to vulnerability reports?
+* Basic: Executive support to respond to reports.
+* Advanced: Defined policies/processes/etc. for responding to reports.
+* Expert: Dedicated staff for responding to reports.
 
-- **Triage**: as new issues are reported, you'll need to review the submissions to determine which are legitimate (and which need more info from the reporter, are invalid or duplicates, etc). You should try to triage new issues within a week at most (and, preferably, daily).
-- **Tracking**: once issues are confirmed and accepted for a fix, you'll need to track them to their conclusion, and make sure they don't get lost. This is especially important for lower-severity issues: it's common for them to continually get de-prioritized and hence never get fixed. We're committing to a 90-day SLA ([see below for more details](#sla)), so you'll need to keep an eye on that.
-- **Communication**: communicate updates to reporters with open issues. Usually this'll just be "thanks we got it, expect a fix $whenever" at the beginning, and then "ok it's fixed!" at the end. But, if something changes during the time the issue is open, you should communicate that to the reporter.
+__Engineering__: How does your project manage vulnerabilities?
+* Basic: All bugs are tracked to resolution.
+* Advanced: Security bugs are tracked to resolution, deferral, or acceptance.
+* Expert: Security bug classes are tracked.
 
-Generally, we think you should expect to spend on the order of 4-8 hours a week on bounty management tasks. If you're spending appreciably more, please contact the bounty team and let us know; that might indicate that somethings wrong.
+__Communications__: How does your project communicate about its vulnerabilities?
+* Basic: You have a channel to distribute advisories to impacted parties.
+* Advanced: You have tailored channels for each of your audiences.
+* Expert: You have an information sharing program to coordinate disclosure.
 
-Time tracking: time spent on these management tasks should be Tocked as `FIXME / Bug Bounty`, but time spent on actually resolving the issues should be Tocked to the project itself.
+__Analytics__: How does your project improve its security?
+* Basic: Bug tracking data is used to measure code quality over time.
+* Advanced: Automated development practices eliminate security bug classes.
+* Expert: Instrumentation captures exploit attempts and triggers mitigation.
 
-<a id="sla"></a>
+__Incentives__: How does your project encourage engagement?
+* Basic: Clear legal statement that protects researchers who report bugs.
+* Advanced: Financial rewards.
+* Expert: Financial rewards tailored to your project's vulnerability market.
+
+In a nutshell, projects will have bugs reported to them, and their ability to
+deal with them gracefully will be the key to success.  Your project needs to be
+mature enough to address any reported issues in a reasonable amount of time.
+18F's Bug Bounty Team is here to provide assistance, but not oversight!  Your
+project will own all the responsibilities, from making sure the reports get a
+response, to making sure the incentives are properly aligned.
+
 ### SLAs
 
-We have one Big Formal SLA: **we've committed to resolve reported issues within 90 days**. 
+Projects that participate in the bug bounty program inherit a SLA.  Issues
+must be resolved within 90 days of being reported, but note that "resolved" for
+the purposes of the bug bounty program does not necessarily mean fixed.  For
+example, vulnerabilities that you determine will not be fixed within 90 days can
+be resolved by paying the reporter and communicating your plan.  Also note that
+bug bounty resolution is entirely separate from any federal policy and
+compliance with one does not confer compliance with the other.
 
-*[Note that "resolve" doesn't always have to mean "fix"; it's completely OK to decide that an issue is too low-risk to actually fix. So in that case "resolve" would just mean "pay the reporter, but tell them we don't necessarily plan to fix within 90 days."]*
+The Bug Bounty Team will notify you about unresolved reports on every half-life 
+(i.e. Day 45, 22, 11, 5, 3, 2, and 1) to help you track issues as they get
+closer to the SLA.
 
-We'll notify you about open issues on every half-life (i.e. Day 45, 22, 11, 5, 3, 2, and 1) to help you track issues as they get closer to their deadline.
+#### Your Project's Participation
 
-However, we *suggest* you aim to hit these informal SLAs based on the issue's risk:
+Regardless of what level of maturity your project has, you can expect the
+following tasks to come your way:
 
-* Tier 1: 1 week
-* Tier 2: 30 days
-* Tier 3: 60 days
+* __Triage__: As issues are reported, you'll need to review the reports to
+qualify them.  Some may contain all the information you need, others may be
+lacking and require follow-up.  Some will be serious, others may be invalid.
+Some of the serious ones may qualify as a
+[security incident](https://handbook.18f.gov/security-incidents/) .   Sometimes
+you may see duplicates, of both the serious and the invalid.  In any case, we
+recommend you triage issues within a week, if not daily.  Triaging is complete
+when you have enough information from the reporter to implement a fix and assign
+it a priority, or enough information to dismiss it as not a bug.
 
-### Ready to participate?
+* __Tracking__: Once you've qualified a report as a vulnerability, you'll
+need to track it to its conclusion.  This is especially important for
+lower-risk vulnerabilities as they are at high risk of not being prioritized
+above other work.  Tracking is complete when you have a permanent, searchable
+record of the decisions that were made leading up to the resolution, deferral,
+or acceptance of the bug.
 
-**Yay!** Contact us in `#bug-bounty` and we'll get you set up. 
+* __Communication__: Reporters expect updates on the issues they've
+reported. Usually nothing more at the beginning than "thanks we got it, expect a
+fix $whenever", and then "ok it's fixed!" at the end. If something changes
+while the vulnerability is still open, though, you should communicate that to
+the reporter.  You may also have to communicate with customers, partners, and
+others depending on the scope of the bug.  Communications is complete once all
+of the impacted parties have been informed of the steps you've taken to resolve
+the bug, and any additional steps they may need to take in response.
 
-And, as things progress, hit us up in the same channel with questions any time.
+#### Time Commitment
+
+Time spent on those bug bounty tasks should be Tocked as `FIXME / Bug Bounty`,
+but time spent on actually resolving the issues should be Tocked to the project 
+itself.  Expect to spend on the order of 4-8 hours a week on bounty management
+tasks. If at any point you're spending more, that might indicate something is
+wrong and you should let the bug bounty team know.
+
+## Ready To Participate?
+
+**Yay!** Contact us in `#bug-bounty` to start the conversation! 

--- a/content/project-instructions.md
+++ b/content/project-instructions.md
@@ -5,38 +5,43 @@ researchers, and everyone that depends on our software.
 
 ### Vulnerability Maturity Model
 
-Our partner, HackerOne, has [a maturity model for vulnerability coordination](https://www.hackerone.com/blog/vulnerability-coordination-maturity-model).  It
-is not strictly necessary that your project have expert-level maturity in every
-capability to participate, but in general, more maturity is better.
+Our partner, HackerOne, has [a maturity model for vulnerability
+coordination](https://www.hackerone.com/blog/vulnerability-coordination-maturity-model).
+To guarantee that your project's participation in the bug bounty program is a
+success, we expect you to be willing to have:
 
-__Organizational__: How does your project respond to vulnerability reports?
-* Basic: Executive support to respond to reports.
-* Advanced: Defined policies/processes/etc. for responding to reports.
-* Expert: Dedicated staff for responding to reports.
+* Staff dedicated, on a possibly rotating basis, to responding to vulnerability
+reports. The staff need not be security experts, but for availability, you must
+have two or more staff dedicated to responding and they must be reachable by a 
+[Slack User Group](https://handbook.18f.gov/slack/#groups).
 
-__Engineering__: How does your project manage vulnerabilities?
-* Basic: All bugs are tracked to resolution.
-* Advanced: Security bugs are tracked to resolution, deferral, or acceptance.
-* Expert: Security bug classes are tracked.
+* A private GitHub repo for tracking vulnerability reports to resolution.  It
+need not be an [issues-only
+repo](https://help.github.com/articles/creating-an-issues-only-repository/) but
+it must be private.  Issues must track both vulnerability instances and
+vulnerability classes; a reported cross-site scripting vulnerability must also
+be tracked as a separate issue to find and fix all other cross-site scripting
+vulnerabilities, and when found must also be tracked separately.
 
-__Communications__: How does your project communicate about its vulnerabilities?
-* Basic: You have a channel to distribute advisories to impacted parties.
-* Advanced: You have tailored channels for each of your audiences.
-* Expert: You have an information sharing program to coordinate disclosure.
+* Methods to inform parties impacted by a reported vulnerability, which will
+depend on the nature your project.  For example, if your project is an
+interactive service, this could be a notice on the front page; if your project
+is a code library, this could be an update to the release notes.  If your
+project features both or more, you must be able to inform each of your
+audiences.
 
-__Analytics__: How does your project improve its security?
-* Basic: Bug tracking data is used to measure code quality over time.
-* Advanced: Automated development practices eliminate security bug classes.
-* Expert: Instrumentation captures exploit attempts and triggers mitigation.
+* Automated development practices that mitigate classes of vulnerabilities.  For
+example, your project uses a framework that automatically escapes output so that
+input doesn't have to be manually escaped, or your project automatically fuzzes
+all commits before deploying to production.
 
-__Incentives__: How does your project encourage engagement?
-* Basic: Clear legal statement that protects researchers who report bugs.
-* Advanced: Financial rewards.
-* Expert: Financial rewards tailored to your project's vulnerability market.
+* Enrolled in the [18F Vulnerability Disclosure
+Policy](https://github.com/18F/vulnerability-disclosure-policy/blob/master/vulnerability-disclosure-policy.md).
 
 In a nutshell, projects will have bugs reported to them, and their ability to
 deal with them gracefully will be the key to success.  Your project needs to be
-mature enough to address any reported issues in a reasonable amount of time.
+mature enough to address any reported issues in a reasonable amount of time, and
+to ensure that it isn't having the same kind of issues reported over time. 
 18F's Bug Bounty Team is here to provide assistance, but not oversight!  Your
 project will own all the responsibilities, from making sure the reports get a
 response, to making sure the incentives are properly aligned.


### PR DESCRIPTION
Participation slots are limited, so we want choose only the projects that are most likely to succeed.  Also, projects inherit an SLA that is separate from federal policy.  Participation tasks now include definitions of done.